### PR TITLE
Handle missing declarativeNetRequest debug API

### DIFF
--- a/background.js
+++ b/background.js
@@ -92,16 +92,12 @@ function initializeExtension() {
 
   // Set up declarativeNetRequest debug listener (only available in debug mode)
   try {
-    if (chrome.declarativeNetRequest && chrome.declarativeNetRequest.onRuleMatchedDebug) {
-      chrome.declarativeNetRequest.onRuleMatchedDebug.addListener(
-        function(info) {
-          console.log('Rule matched for URL:', info.request.url);
-          if (info.request.url.includes('onepasswdfill')) {
-            handleOnePasswordFill(info);
-          }
-        }
-      );
-    }
+    chrome.declarativeNetRequest?.onRuleMatchedDebug?.addListener((info) => {
+      console.log('Rule matched for URL:', info.request.url);
+      if (info.request.url.includes('onepasswdfill')) {
+        handleOnePasswordFill(info);
+      }
+    });
   } catch (error) {
     console.log('DeclarativeNetRequest debug API not available:', error);
   }


### PR DESCRIPTION
## Summary
- avoid crashing when `declarativeNetRequest.onRuleMatchedDebug` is unavailable

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68a3d251453c832d909a7a8427630624